### PR TITLE
fix: TW Endpoint Helper 404 when no rest route found for slug

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,12 +5,10 @@ Closes #[ISSUE_ID]
 ## To Review
 
 - [ ] Checkout Branch.
-- [ ] Start Lando, if it is not already running: `lando start`.
-- [ ] (Optional) Update database:
-  - Delete any `.sql.gz` files from your `./reference` directory.
-  - Run `terminus backup:get --element=db --to=./reference -- the-world.live`.
-  - Run `npm run refresh`.
-- [ ] Go to http://dev-the-world.lndo.site/.
+- [ ] If you have a dev server already running, shut it down: `docker compose down`.
+- [ ] Delete the current image: `docker rmi the-world-cms-wordpress-wordpress:latest`.
+- [ ] Start up dev server: `docker compose up`.
+- [ ] Go to http://localhost:8090/wp-login.php.
 
 > ...then...
 

--- a/wp-content/plugins/tw-endpoint-helper/tw-endpoint-helper.php
+++ b/wp-content/plugins/tw-endpoint-helper/tw-endpoint-helper.php
@@ -182,7 +182,7 @@ function peh_route_alias( WP_REST_Request $request ) {
 					}
 				} else {
 
-					$response['status'] = 500;
+					$response['status'] = 404;
 				}
 			}
 		} else {


### PR DESCRIPTION
- 404 when no rest route found for slug
- Updates pull request template.

## To Review

- [x] Checkout Branch.
- [x] If you have a dev server already running, shut it down: `docker compose down`.
- [x] Delete the current image: `docker rmi the-world-cms-wordpress-wordpress:latest`.
- [x] Start up dev server: `docker compose up`.
- [ ] Go to http://localhost:8090/index.php/wp-json/tw/v2/alias?_fields=id%2Ctype%2Ctaxonomy%2Clink%2Cattributes&slug=news%2Fshared

> ...then...

- [ ] Ensure you get a 404 response
