### PR TITLE
41: tw-rss-helper optimize gathering of enclosure attr values

### DIFF
--- a/wp-content/plugins/tw-rss-helper/includes/rss.php
+++ b/wp-content/plugins/tw-rss-helper/includes/rss.php
@@ -53,7 +53,7 @@ function tw_rss_helper_audio_enclosure() {
 		'<enclosure url="%1$s" type="%2$s" length="%3$s"/>',
 		$audio_media['url'],
 		$audio_media['mime_type'],
-		$audio_metadata['filesize']
+		$audio_media['filesize']
 	);
 
 	/**


### PR DESCRIPTION
Closes #41

- optimize tw-rss-helper plugin to get enclosure attribute values from database before resorting to fetching headers.

## To Review

- [ ] Checkout Branch.
- [ ] If you have a dev server already running, shut it down: `docker compose down`.
- [ ] Delete the current image: `docker rmi the-world-cms-wordpress-wordpress:latest`.
- [ ] Start up dev server: `docker compose up`.
- [ ] Go to http://localhost:8090/feed.

> ...then...

- [ ] Ensure URL loads and adds enclosures to items with audio as expected.
