### PR TITLE
fix(theme): add filters to disable taxonomy filtering in acf relationship fields

### DIFF
--- a/wp-content/plugins/advanced-custom-fields-pro/includes/fields/class-acf-field-relationship.php
+++ b/wp-content/plugins/advanced-custom-fields-pro/includes/fields/class-acf-field-relationship.php
@@ -431,7 +431,7 @@ if ( ! class_exists( 'acf_field_relationship' ) ) :
 
 			?>
 <div <?php echo acf_esc_attrs( $atts ); ?>>
-	
+
 			<?php
 			acf_hidden_input(
 				array(
@@ -440,7 +440,7 @@ if ( ! class_exists( 'acf_field_relationship' ) ) :
 				)
 			);
 			?>
-	
+
 			<?php
 
 			/* filters */
@@ -494,10 +494,10 @@ if ( ! class_exists( 'acf_field_relationship' ) ) :
 					);
 					?>
 		</div>
-				<?php endif; ?>		
+				<?php endif; ?>
 	</div>
 			<?php endif; ?>
-	
+
 	<div class="selection">
 		<div class="choices">
 			<ul class="acf-bl list choices-list"></ul>

--- a/wp-content/themes/the-world/acf-json/group_622a69c137333.json
+++ b/wp-content/themes/the-world/acf-json/group_622a69c137333.json
@@ -27,7 +27,9 @@
             "ui": 0,
             "return_format": "value",
             "ajax": 0,
-            "placeholder": ""
+            "placeholder": "",
+            "create_options": 0,
+            "save_options": 0
         },
         {
             "key": "field_622a69ed0dfde",
@@ -83,15 +85,20 @@
             "post_type": [
                 "segment"
             ],
-            "post_status": "",
-            "taxonomy": "",
+            "post_status": [
+                "publish"
+            ],
             "filters": [
                 "search"
             ],
             "return_format": "id",
             "min": "",
             "max": 20,
-            "elements": ""
+            "allow_in_bindings": 1,
+            "elements": "",
+            "bidirectional": 0,
+            "taxonomy": [],
+            "bidirectional_target": []
         },
         {
             "key": "field_622a6a5bbd407",
@@ -123,7 +130,8 @@
             "return_format": "id",
             "field_type": "multi_select",
             "allow_null": 1,
-            "multiple": 0
+            "multiple": 0,
+            "bidirectional_target": []
         },
         {
             "key": "field_622a6a928a4f6",
@@ -150,7 +158,8 @@
             "show_in_graphql": 1,
             "display_format": "F j, Y",
             "return_format": "Y-m-d",
-            "first_day": 1
+            "first_day": 1,
+            "default_to_current_date": 0
         },
         {
             "key": "field_622a6ac11faf8",
@@ -177,7 +186,8 @@
             "show_in_graphql": 0,
             "display_format": "F j, Y",
             "return_format": "U",
-            "first_day": 1
+            "first_day": 1,
+            "default_to_current_date": 0
         },
         {
             "key": "field_622a6ba1511d4",
@@ -218,9 +228,10 @@
     "active": true,
     "description": "",
     "show_in_rest": 1,
+    "display_title": "",
     "show_in_graphql": 1,
     "graphql_field_name": "audioFields",
     "map_graphql_types_from_location_rules": 0,
     "graphql_types": "",
-    "modified": 1688686172
+    "modified": 1761592755
 }

--- a/wp-content/themes/the-world/acf-json/group_6470dbd403806.json
+++ b/wp-content/themes/the-world/acf-json/group_6470dbd403806.json
@@ -20,16 +20,19 @@
             "post_type": [
                 "post"
             ],
-            "post_status": "",
-            "taxonomy": "",
+            "post_status": [
+                "publish"
+            ],
             "filters": [
-                "search",
-                "taxonomy"
+                "search"
             ],
             "return_format": "id",
-            "min": 0,
-            "max": 0,
-            "elements": [],
+            "min": "",
+            "max": "",
+            "allow_in_bindings": 1,
+            "elements": "",
+            "bidirectional": 0,
+            "taxonomy": [],
             "bidirectional_target": []
         }
     ],
@@ -56,6 +59,7 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
+    "display_title": "",
     "show_in_graphql": 1,
     "graphql_field_name": "landingPage",
     "map_graphql_types_from_location_rules": 1,
@@ -72,5 +76,5 @@
         "SocialTag",
         "Tag"
     ],
-    "modified": 1692816144
+    "modified": 1761591836
 }

--- a/wp-content/themes/the-world/functions.php
+++ b/wp-content/themes/the-world/functions.php
@@ -361,3 +361,54 @@ if ( ! function_exists( 'tw_oembed_dataparse_tiktok' ) ) {
 	}
 }
 add_filter( 'oembed_dataparse', 'tw_oembed_dataparse_tiktok', 20, 3 );
+
+
+/**
+ * Alter field settings for relationship fields' configuration.
+ *
+ * @param array $field Field settings array.
+ * @return array Altered field settings array.
+ */
+function tw_acf_prepare_field_relationship_taxonomy( $field ) {
+	// Do not render taxonomy select field. We have too many terms.
+	// TODO: Figure out how to render or use a more performant input for this setting.
+	if ( 'taxonomy' === $field['_name'] ) {
+		return false;
+	}
+
+	// Remove taxonomy filtering option.
+	if ( 'filters' === $field['_name'] ) {
+		unset( $field['choices']['taxonomy'] );
+	}
+
+	return $field;
+}
+add_filter( 'acf/prepare_field', 'tw_acf_prepare_field_relationship_taxonomy', 10 );
+
+/**
+ * Alter pre-render settings for relationship fields.
+ *
+ * @param array $field Field settings array.
+ * @return array Altered field settings array.
+ */
+function tw_acf_pre_render_field_relationship_taxonomy( $field ) {
+
+	if ( 'relationship' === $field['type'] ) {
+		// Make sure published posts can be selected.
+		$field['post_status'] = array( 'publish' );
+
+		// Make sure taxonomy is not used in queries.
+		$field['taxonomy'] = null;
+
+		// Makes sure taxonomy filter input is not rendered.
+		$field['filters'] = array_filter(
+			$field['filters'],
+			static function ( $v ) {
+				return 'taxonomy' !== $v;
+			}
+		);
+	}
+
+	return $field;
+}
+add_filter( 'acf/pre_render_field', 'tw_acf_pre_render_field_relationship_taxonomy', 10 );


### PR DESCRIPTION
## To Review

- [x] Checkout Branch.
- [x] If you have a dev server already running, shut it down: `docker compose down`.
- [x] Delete the current image: `docker rmi the-world-cms-wordpress-wordpress:latest`.
- [x] Start up dev server: `docker compose up`.
- [x] Go to http://localhost:8090/wp-login.php.

> ...then...

- [x] Edit the home page.
- [x] Ensure page loads and doesn't not become unresponsive.
- [x] Edit the Landing Page ACF field group.
- [x] Ensure page loads and doesn't not become unresponsive.
- [x] Ensure taxonomy filter and filters option is not shown.
