### PR TITLE
Register contributor taxonomy to episodes

### DIFF
--- a/wp-content/plugins/tw-contributors/tw-contributors.php
+++ b/wp-content/plugins/tw-contributors/tw-contributors.php
@@ -53,7 +53,7 @@ function tw_contributors_taxonomy() {
 		'graphql_single_name' => 'contributor',
 		'graphql_plural_name' => 'contributors',
 	);
-	register_taxonomy( 'contributor', array( 'post', 'attachment', 'segment' ), $args );
+	register_taxonomy( 'contributor', array( 'post', 'attachment', 'segment', 'episode' ), $args );
 }
 add_action( 'init', 'tw_contributors_taxonomy', 0 );
 


### PR DESCRIPTION
## To Review

- [ ] Checkout Branch.
- [ ] If you have a dev server already running, shut it down: `docker compose down`.
- [ ] Delete the current image: `docker rmi the-world-cms-wordpress-wordpress:latest`.
- [ ] Start up dev server: `docker compose up`.
- [ ] Go to http://localhost:8090/wp-login.php.

> ...then...

- [ ] Episodes dash board should now have a column for Contributors
- [ ] When editing an episode you should now have a Contributors taxonomy input in the sidebar.
