### PR TITLE
Feat/station importer

### DIFF
--- a/wp-content/plugins/tw-stations/admin/class-tw-station-admin.php
+++ b/wp-content/plugins/tw-stations/admin/class-tw-station-admin.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Admin page for importing stations from a CSV file.
+ *
+ * @package tw_stations
+ */
+
+// No direct access allowed.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
+
+/**
+ * Registers and renders the station import admin page.
+ */
+class TW_Station_Admin {
+
+	const NONCE_ACTION = 'tw_station_import';
+	const NONCE_FIELD  = 'tw_station_import_nonce';
+	const PAGE_SLUG    = 'tw-station-import';
+
+	/**
+	 * Register hooks.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'admin_menu', array( __CLASS__, 'register_menu' ) );
+	}
+
+	/**
+	 * Add submenu under Stations.
+	 *
+	 * @return void
+	 */
+	public static function register_menu() {
+		add_submenu_page(
+			'edit.php?post_type=station',
+			__( 'Import Stations', 'tw-stations' ),
+			__( 'Import Stations', 'tw-stations' ),
+			'manage_options',
+			self::PAGE_SLUG,
+			array( __CLASS__, 'render_page' )
+		);
+	}
+
+	/**
+	 * Render the import page, handling form submission if present.
+	 *
+	 * @return void
+	 */
+	public static function render_page() {
+		$results = null;
+		$error   = null;
+
+		if ( isset( $_POST[ self::NONCE_FIELD ] ) ) {
+			if ( ! check_admin_referer( self::NONCE_ACTION, self::NONCE_FIELD ) ) {
+				$error = 'Security check failed. Please try again.';
+			} elseif ( empty( $_FILES['station_csv']['tmp_name'] ) || UPLOAD_ERR_OK !== $_FILES['station_csv']['error'] ) {
+				$error = 'No file uploaded or upload error occurred.';
+			} else {
+				$tmp_path = $_FILES['station_csv']['tmp_name']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+				$ext      = strtolower( pathinfo( sanitize_file_name( $_FILES['station_csv']['name'] ), PATHINFO_EXTENSION ) );
+
+				if ( 'csv' !== $ext ) {
+					$error = 'Please upload a .csv file.';
+				} else {
+					$update    = ! empty( $_POST['update_existing'] );
+					$processor = new TW_Station_Import_Processor();
+					$results   = $processor->process_file( $tmp_path, $update );
+				}
+			}
+		}
+
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Import Stations', 'tw-stations' ); ?></h1>
+			<p><?php esc_html_e( 'Upload a CSV file to import stations. Existing stations are matched by call letters or post slug.', 'tw-stations' ); ?></p>
+
+			<?php if ( $error ) : ?>
+				<div class="notice notice-error"><p><?php echo esc_html( $error ); ?></p></div>
+			<?php endif; ?>
+
+			<?php if ( $results ) : ?>
+				<?php self::render_results( $results ); ?>
+			<?php endif; ?>
+
+			<form method="post" enctype="multipart/form-data">
+				<?php wp_nonce_field( self::NONCE_ACTION, self::NONCE_FIELD ); ?>
+
+				<table class="form-table" role="presentation">
+					<tr>
+						<th scope="row">
+							<label for="station_csv"><?php esc_html_e( 'CSV File', 'tw-stations' ); ?></label>
+						</th>
+						<td>
+							<input type="file" id="station_csv" name="station_csv" accept=".csv" required>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Options', 'tw-stations' ); ?></th>
+						<td>
+							<label>
+								<input type="checkbox" name="update_existing" value="1">
+								<?php esc_html_e( 'Update existing stations (default: skip)', 'tw-stations' ); ?>
+							</label>
+						</td>
+					</tr>
+				</table>
+
+				<?php submit_button( __( 'Import', 'tw-stations' ) ); ?>
+			</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render the results table after an import.
+	 *
+	 * @param array $results Results from TW_Station_Import_Processor::process_file().
+	 * @return void
+	 */
+	private static function render_results( $results ) {
+		$created = $results['created'];
+		$updated = $results['updated'];
+		$skipped = $results['skipped'];
+		$errors  = $results['errors'];
+		?>
+		<div class="notice notice-success">
+			<p>
+				<?php
+				echo esc_html(
+					sprintf(
+						/* translators: 1: created count 2: updated count 3: skipped count 4: error count */
+						__( 'Import complete — Created: %1$d, Updated: %2$d, Skipped: %3$d, Errors: %4$d', 'tw-stations' ),
+						count( $created ),
+						count( $updated ),
+						count( $skipped ),
+						count( $errors )
+					)
+				);
+				?>
+			</p>
+		</div>
+
+		<?php if ( $errors ) : ?>
+			<h3><?php esc_html_e( 'Errors', 'tw-stations' ); ?></h3>
+			<ul style="color:#d63638">
+				<?php foreach ( $errors as $item ) : ?>
+					<li>
+						<?php if ( $item['title'] ) : ?>
+							<strong><?php echo esc_html( $item['title'] ); ?>:</strong>
+						<?php endif; ?>
+						<?php echo esc_html( $item['message'] ); ?>
+					</li>
+				<?php endforeach; ?>
+			</ul>
+		<?php endif; ?>
+
+		<?php if ( $created ) : ?>
+			<details>
+				<summary><?php echo esc_html( sprintf( __( 'Created (%d)', 'tw-stations' ), count( $created ) ) ); ?></summary>
+				<ul>
+					<?php foreach ( $created as $item ) : ?>
+						<li>
+							<a href="<?php echo esc_url( get_edit_post_link( $item['id'] ) ); ?>">
+								<?php echo esc_html( $item['title'] ); ?>
+							</a>
+						</li>
+					<?php endforeach; ?>
+				</ul>
+			</details>
+		<?php endif; ?>
+
+		<?php if ( $updated ) : ?>
+			<details>
+				<summary><?php echo esc_html( sprintf( __( 'Updated (%d)', 'tw-stations' ), count( $updated ) ) ); ?></summary>
+				<ul>
+					<?php foreach ( $updated as $item ) : ?>
+						<li>
+							<a href="<?php echo esc_url( get_edit_post_link( $item['id'] ) ); ?>">
+								<?php echo esc_html( $item['title'] ); ?>
+							</a>
+						</li>
+					<?php endforeach; ?>
+				</ul>
+			</details>
+		<?php endif; ?>
+
+		<?php if ( $skipped ) : ?>
+			<details>
+				<summary><?php echo esc_html( sprintf( __( 'Skipped (%d)', 'tw-stations' ), count( $skipped ) ) ); ?></summary>
+				<ul>
+					<?php foreach ( $skipped as $item ) : ?>
+						<li>
+							<a href="<?php echo esc_url( get_edit_post_link( $item['id'] ) ); ?>">
+								<?php echo esc_html( $item['title'] ); ?>
+							</a>
+						</li>
+					<?php endforeach; ?>
+				</ul>
+			</details>
+		<?php endif; ?>
+		<?php
+	}
+}

--- a/wp-content/plugins/tw-stations/admin/class-tw-station-admin.php
+++ b/wp-content/plugins/tw-stations/admin/class-tw-station-admin.php
@@ -15,9 +15,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class TW_Station_Admin {
 
-	const NONCE_ACTION = 'tw_station_import';
-	const NONCE_FIELD  = 'tw_station_import_nonce';
-	const PAGE_SLUG    = 'tw-station-import';
+	const NONCE_ACTION        = 'tw_station_import';
+	const NONCE_FIELD         = 'tw_station_import_nonce';
+	const DELETE_NONCE_ACTION = 'tw_station_delete_all';
+	const DELETE_NONCE_FIELD  = 'tw_station_delete_all_nonce';
+	const PAGE_SLUG           = 'tw-station-import';
 
 	/**
 	 * Register hooks.
@@ -50,8 +52,10 @@ class TW_Station_Admin {
 	 * @return void
 	 */
 	public static function render_page() {
-		$results = null;
-		$error   = null;
+		$results        = null;
+		$error          = null;
+		$delete_results = null;
+		$delete_error   = null;
 
 		if ( isset( $_POST[ self::NONCE_FIELD ] ) ) {
 			if ( ! check_admin_referer( self::NONCE_ACTION, self::NONCE_FIELD ) ) {
@@ -70,6 +74,14 @@ class TW_Station_Admin {
 					$results   = $processor->process_file( $tmp_path, $update );
 				}
 			}
+		} elseif ( isset( $_POST[ self::DELETE_NONCE_FIELD ] ) ) {
+			if ( ! check_admin_referer( self::DELETE_NONCE_ACTION, self::DELETE_NONCE_FIELD ) ) {
+				$delete_error = 'Security check failed. Please try again.';
+			} elseif ( empty( $_POST['confirm_delete_all'] ) ) {
+				$delete_error = 'You must check the confirmation box to delete all stations.';
+			} else {
+				$delete_results = self::delete_all_stations();
+			}
 		}
 
 		?>
@@ -79,6 +91,26 @@ class TW_Station_Admin {
 
 			<?php if ( $error ) : ?>
 				<div class="notice notice-error"><p><?php echo esc_html( $error ); ?></p></div>
+			<?php endif; ?>
+
+			<?php if ( $delete_error ) : ?>
+				<div class="notice notice-error"><p><?php echo esc_html( $delete_error ); ?></p></div>
+			<?php endif; ?>
+
+			<?php if ( null !== $delete_results ) : ?>
+				<div class="notice notice-success">
+					<p>
+						<?php
+						echo esc_html(
+							sprintf(
+								/* translators: %d: number of deleted stations */
+								__( 'Deleted %d station(s).', 'tw-stations' ),
+								$delete_results
+							)
+						);
+						?>
+					</p>
+				</div>
 			<?php endif; ?>
 
 			<?php if ( $results ) : ?>
@@ -110,8 +142,58 @@ class TW_Station_Admin {
 
 				<?php submit_button( __( 'Import', 'tw-stations' ) ); ?>
 			</form>
+
+			<hr style="margin: 2em 0;">
+
+			<h2 style="color:#d63638"><?php esc_html_e( 'Danger Zone', 'tw-stations' ); ?></h2>
+			<p><?php esc_html_e( 'Permanently delete all station posts. This cannot be undone.', 'tw-stations' ); ?></p>
+
+			<form method="post">
+				<?php wp_nonce_field( self::DELETE_NONCE_ACTION, self::DELETE_NONCE_FIELD ); ?>
+				<table class="form-table" role="presentation">
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Confirm', 'tw-stations' ); ?></th>
+						<td>
+							<label>
+								<input type="checkbox" name="confirm_delete_all" value="1">
+								<?php esc_html_e( 'I understand this will permanently delete all stations and cannot be undone.', 'tw-stations' ); ?>
+							</label>
+						</td>
+					</tr>
+				</table>
+				<?php submit_button( __( 'Delete All Stations', 'tw-stations' ), 'delete', 'submit', true, array( 'style' => 'background:#d63638;border-color:#d63638;color:#fff;' ) ); ?>
+			</form>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Permanently delete all station posts using bulk SQL queries.
+	 *
+	 * Bypasses wp_delete_post() to avoid N×10 individual queries.
+	 *
+	 * @return int Number of posts deleted.
+	 */
+	private static function delete_all_stations() {
+		global $wpdb;
+
+		$ids = $wpdb->get_col(
+			"SELECT ID FROM {$wpdb->posts} WHERE post_type = 'station'"
+		);
+
+		if ( empty( $ids ) ) {
+			return 0;
+		}
+
+		$ids_in = implode( ',', array_map( 'intval', $ids ) );
+
+		$wpdb->query( "DELETE FROM {$wpdb->postmeta} WHERE post_id IN ($ids_in)" );         // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->term_relationships} WHERE object_id IN ($ids_in)" ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->posts} WHERE ID IN ($ids_in)" );                  // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		clean_post_cache( $ids );
+
+		return count( $ids );
 	}
 
 	/**

--- a/wp-content/plugins/tw-stations/cli/class-tw-station-importer.php
+++ b/wp-content/plugins/tw-stations/cli/class-tw-station-importer.php
@@ -105,11 +105,10 @@ class TW_Station_Importer {
 			if ( count( $row ) !== count( $header ) ) {
 				continue;
 			}
-			$data         = array_combine( $header, $row );
-			$title        = trim( $data['title'] );
-			$call_letters = trim( $data['call_letters'] );
+			$data  = array_combine( $header, $row );
+			$title = trim( $data['title'] );
 
-			$existing = $this->find_existing_station( $title, $call_letters );
+			$existing = $this->find_existing_station( $title );
 
 			if ( $existing ) {
 				if ( $update ) {
@@ -138,37 +137,12 @@ class TW_Station_Importer {
 	}
 
 	/**
-	 * Find an existing station by call letters or title slug.
+	 * Find an existing station by title slug.
 	 *
-	 * @param string $title        Post title.
-	 * @param string $call_letters Station call letters.
+	 * @param string $title Post title.
 	 * @return int|null Post ID or null.
 	 */
-	private function find_existing_station( $title, $call_letters ) {
-		if ( $call_letters ) {
-			$posts = get_posts(
-				array(
-					'post_type'      => 'station',
-					'posts_per_page' => 1,
-					'fields'         => 'ids',
-					'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-						'relation' => 'OR',
-						array(
-							'key'   => 'frequency_info_call_letters',
-							'value' => $call_letters,
-						),
-						array(
-							'key'   => 'station_info_call_letters',
-							'value' => $call_letters,
-						),
-					),
-				)
-			);
-			if ( $posts ) {
-				return $posts[0];
-			}
-		}
-
+	private function find_existing_station( $title ) {
 		$post = get_page_by_path( sanitize_title( $title ), OBJECT, 'station' );
 		return $post ? $post->ID : null;
 	}

--- a/wp-content/plugins/tw-stations/cli/class-tw-station-importer.php
+++ b/wp-content/plugins/tw-stations/cli/class-tw-station-importer.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * WP-CLI command to import stations from a CSV file.
+ *
+ * Usage:
+ *   wp tw-station import /path/to/stations.csv
+ *   wp tw-station import /path/to/stations.csv --update
+ *   wp tw-station import /path/to/stations.csv --dry-run
+ *
+ * @package tw_stations
+ */
+
+// No direct access allowed.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
+
+/**
+ * Manages station import commands.
+ */
+class TW_Station_Importer {
+
+	/**
+	 * Import stations from a CSV file.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <file>
+	 * : Absolute or relative path to the CSV file.
+	 *
+	 * [--update]
+	 * : Update existing stations instead of skipping them.
+	 *
+	 * [--dry-run]
+	 * : Preview what would be created or updated without making changes.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp tw-station import /path/to/the-world-stations-list.csv
+	 *     wp tw-station import /path/to/the-world-stations-list.csv --update
+	 *     wp tw-station import /path/to/the-world-stations-list.csv --dry-run
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Associative arguments (flags).
+	 * @return void
+	 */
+	public function import( $args, $assoc_args ) {
+		$file    = $args[0];
+		$update  = \WP_CLI\Utils\get_flag_value( $assoc_args, 'update', false );
+		$dry_run = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+
+		if ( ! file_exists( $file ) ) {
+			WP_CLI::error( "File not found: $file" );
+		}
+
+		if ( $dry_run ) {
+			WP_CLI::log( 'Dry run mode — no changes will be saved.' );
+			$this->run_dry_run( $file, $update );
+			return;
+		}
+
+		$processor = new TW_Station_Import_Processor();
+		$results   = $processor->process_file( $file, $update );
+
+		foreach ( $results['created'] as $item ) {
+			WP_CLI::log( "Created: {$item['title']} (ID: {$item['id']})" );
+		}
+		foreach ( $results['updated'] as $item ) {
+			WP_CLI::log( "Updated: {$item['title']} (ID: {$item['id']})" );
+		}
+		foreach ( $results['skipped'] as $item ) {
+			WP_CLI::log( "Skipped: {$item['title']} (ID: {$item['id']})" );
+		}
+		foreach ( $results['errors'] as $item ) {
+			WP_CLI::warning( "Error: {$item['title']} — {$item['message']}" );
+		}
+
+		WP_CLI::success(
+			sprintf(
+				'Done. Created: %d, Updated: %d, Skipped: %d, Errors: %d',
+				count( $results['created'] ),
+				count( $results['updated'] ),
+				count( $results['skipped'] ),
+				count( $results['errors'] )
+			)
+		);
+	}
+
+	/**
+	 * Simulate the import without saving anything.
+	 *
+	 * @param string $file   Path to CSV file.
+	 * @param bool   $update Whether update mode is on.
+	 * @return void
+	 */
+	private function run_dry_run( $file, $update ) {
+		$handle = fopen( $file, 'r' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		$header = fgetcsv( $handle );
+
+		$would_create = 0;
+		$would_update = 0;
+		$would_skip   = 0;
+
+		while ( ( $row = fgetcsv( $handle ) ) !== false ) {
+			if ( count( $row ) !== count( $header ) ) {
+				continue;
+			}
+			$data         = array_combine( $header, $row );
+			$title        = trim( $data['title'] );
+			$call_letters = trim( $data['call_letters'] );
+
+			$existing = $this->find_existing_station( $title, $call_letters );
+
+			if ( $existing ) {
+				if ( $update ) {
+					WP_CLI::log( "[DRY RUN] Would update: $title (ID: $existing)" );
+					$would_update++;
+				} else {
+					WP_CLI::log( "[DRY RUN] Would skip: $title (ID: $existing)" );
+					$would_skip++;
+				}
+			} else {
+				WP_CLI::log( "[DRY RUN] Would create: $title" );
+				$would_create++;
+			}
+		}
+
+		fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+
+		WP_CLI::success(
+			sprintf(
+				'Dry run complete. Would create: %d, Would update: %d, Would skip: %d',
+				$would_create,
+				$would_update,
+				$would_skip
+			)
+		);
+	}
+
+	/**
+	 * Find an existing station by call letters or title slug.
+	 *
+	 * @param string $title        Post title.
+	 * @param string $call_letters Station call letters.
+	 * @return int|null Post ID or null.
+	 */
+	private function find_existing_station( $title, $call_letters ) {
+		if ( $call_letters ) {
+			$posts = get_posts(
+				array(
+					'post_type'      => 'station',
+					'posts_per_page' => 1,
+					'fields'         => 'ids',
+					'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+						'relation' => 'OR',
+						array(
+							'key'   => 'frequency_info_call_letters',
+							'value' => $call_letters,
+						),
+						array(
+							'key'   => 'station_info_call_letters',
+							'value' => $call_letters,
+						),
+					),
+				)
+			);
+			if ( $posts ) {
+				return $posts[0];
+			}
+		}
+
+		$post = get_page_by_path( sanitize_title( $title ), OBJECT, 'station' );
+		return $post ? $post->ID : null;
+	}
+}
+
+WP_CLI::add_command( 'tw-station', 'TW_Station_Importer' );

--- a/wp-content/plugins/tw-stations/includes/class-tw-station-import-processor.php
+++ b/wp-content/plugins/tw-stations/includes/class-tw-station-import-processor.php
@@ -123,7 +123,7 @@ class TW_Station_Import_Processor {
 			return;
 		}
 
-		$existing_id = $this->find_existing_station( $title, $call_letters );
+		$existing_id = $this->find_existing_station( $title );
 
 		if ( $existing_id ) {
 			if ( ! $update ) {
@@ -167,44 +167,14 @@ class TW_Station_Import_Processor {
 	}
 
 	/**
-	 * Find an existing station by call letters or title slug.
+	 * Find an existing station by title slug.
 	 *
-	 * @param string $title        Post title.
-	 * @param string $call_letters Station call letters.
+	 * @param string $title Post title.
 	 * @return int|null Post ID if found, null otherwise.
 	 */
-	private function find_existing_station( $title, $call_letters ) {
-		if ( $call_letters ) {
-			$posts = get_posts(
-				array(
-					'post_type'      => 'station',
-					'posts_per_page' => 1,
-					'fields'         => 'ids',
-					'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-						'relation' => 'OR',
-						array(
-							'key'   => 'frequency_info_call_letters',
-							'value' => $call_letters,
-						),
-						array(
-							'key'   => 'station_info_call_letters',
-							'value' => $call_letters,
-						),
-					),
-				)
-			);
-
-			if ( $posts ) {
-				return $posts[0];
-			}
-		}
-
+	private function find_existing_station( $title ) {
 		$post = get_page_by_path( sanitize_title( $title ), OBJECT, 'station' );
-		if ( $post ) {
-			return $post->ID;
-		}
-
-		return null;
+		return $post ? $post->ID : null;
 	}
 
 	/**

--- a/wp-content/plugins/tw-stations/includes/class-tw-station-import-processor.php
+++ b/wp-content/plugins/tw-stations/includes/class-tw-station-import-processor.php
@@ -1,0 +1,323 @@
+<?php
+/**
+ * Core station import logic, shared by the CLI command and admin UI.
+ *
+ * @package tw_stations
+ */
+
+// No direct access allowed.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
+
+/**
+ * Processes a station CSV and creates/updates station posts.
+ */
+class TW_Station_Import_Processor {
+
+	/**
+	 * ACF field key for the schedule repeater (update_field handles prefixing correctly for repeaters).
+	 */
+	const FIELD_SCHEDULE = 'field_689ba27787ae5';
+
+	/**
+	 * Meta keys and their ACF field key references.
+	 * Using update_post_meta directly ensures the group prefix is applied correctly.
+	 * (update_field on a sub-field key saves without the parent group prefix.)
+	 */
+	const META_FIELDS = array(
+		'frequency_info_call_letters' => 'field_69810ae7bd0f4',
+		'frequency_info_frequency'    => 'field_687ea33a3f5b0',
+		'frequency_info_modulator'    => 'field_687ea40f3f5b1',
+		'location_city'               => 'field_689a4ce0b6e60',
+		'location_state_province'     => 'field_689a4d22b6e62',
+		'location_country'            => 'field_689a4d0ab6e61',
+	);
+
+	/**
+	 * Results collected during import.
+	 *
+	 * @var array
+	 */
+	private $results = array(
+		'created' => array(),
+		'updated' => array(),
+		'skipped' => array(),
+		'errors'  => array(),
+	);
+
+	/**
+	 * Process a CSV file path or resource.
+	 *
+	 * @param string $file_path Absolute path to the CSV file.
+	 * @param bool   $update    Whether to update existing stations.
+	 * @return array Results array with keys: created, updated, skipped, errors.
+	 */
+	public function process_file( $file_path, $update = false ) {
+		$this->results = array(
+			'created' => array(),
+			'updated' => array(),
+			'skipped' => array(),
+			'errors'  => array(),
+		);
+
+		$handle = fopen( $file_path, 'r' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		if ( ! $handle ) {
+			$this->results['errors'][] = array(
+				'title'   => '',
+				'message' => "Could not open file: $file_path",
+			);
+			return $this->results;
+		}
+
+		$header = fgetcsv( $handle );
+		if ( ! $header ) {
+			$this->results['errors'][] = array(
+				'title'   => '',
+				'message' => 'CSV file appears to be empty.',
+			);
+			fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+			return $this->results;
+		}
+
+		$row_num = 1;
+		while ( ( $row = fgetcsv( $handle ) ) !== false ) {
+			$row_num++;
+
+			if ( count( $row ) !== count( $header ) ) {
+				$this->results['errors'][] = array(
+					'title'   => '',
+					'message' => "Row $row_num has wrong column count.",
+				);
+				continue;
+			}
+
+			$data = array_combine( $header, $row );
+			$this->process_row( $data, $update );
+		}
+
+		fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+
+		return $this->results;
+	}
+
+	/**
+	 * Process a single data row.
+	 *
+	 * @param array $data   Associative row data.
+	 * @param bool  $update Whether to update existing stations.
+	 * @return void
+	 */
+	private function process_row( $data, $update ) {
+		$title        = trim( $data['title'] );
+		$call_letters = trim( $data['call_letters'] );
+
+		if ( ! $title ) {
+			$this->results['errors'][] = array(
+				'title'   => '',
+				'message' => 'Empty title, row skipped.',
+			);
+			return;
+		}
+
+		$existing_id = $this->find_existing_station( $title, $call_letters );
+
+		if ( $existing_id ) {
+			if ( ! $update ) {
+				$this->results['skipped'][] = array(
+					'title' => $title,
+					'id'    => $existing_id,
+				);
+				return;
+			}
+
+			$this->save_station_fields( $existing_id, $data );
+			$this->results['updated'][] = array(
+				'title' => $title,
+				'id'    => $existing_id,
+			);
+			return;
+		}
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => $title,
+				'post_type'   => 'station',
+				'post_status' => 'publish',
+			),
+			true
+		);
+
+		if ( is_wp_error( $post_id ) ) {
+			$this->results['errors'][] = array(
+				'title'   => $title,
+				'message' => $post_id->get_error_message(),
+			);
+			return;
+		}
+
+		$this->save_station_fields( $post_id, $data );
+		$this->results['created'][] = array(
+			'title' => $title,
+			'id'    => $post_id,
+		);
+	}
+
+	/**
+	 * Find an existing station by call letters or title slug.
+	 *
+	 * @param string $title        Post title.
+	 * @param string $call_letters Station call letters.
+	 * @return int|null Post ID if found, null otherwise.
+	 */
+	private function find_existing_station( $title, $call_letters ) {
+		if ( $call_letters ) {
+			$posts = get_posts(
+				array(
+					'post_type'      => 'station',
+					'posts_per_page' => 1,
+					'fields'         => 'ids',
+					'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+						'relation' => 'OR',
+						array(
+							'key'   => 'frequency_info_call_letters',
+							'value' => $call_letters,
+						),
+						array(
+							'key'   => 'station_info_call_letters',
+							'value' => $call_letters,
+						),
+					),
+				)
+			);
+
+			if ( $posts ) {
+				return $posts[0];
+			}
+		}
+
+		$post = get_page_by_path( sanitize_title( $title ), OBJECT, 'station' );
+		if ( $post ) {
+			return $post->ID;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Save all ACF fields for a station post.
+	 *
+	 * Frequency info and location fields are written via update_post_meta() with
+	 * explicit meta key names (e.g. frequency_info_frequency, location_city) plus
+	 * their ACF field-key reference rows (_frequency_info_frequency, etc.).
+	 *
+	 * Using update_field() on a group sub-field key saves the value under just the
+	 * sub-field name (e.g. "frequency") instead of the prefixed name
+	 * ("frequency_info_frequency"), so we bypass ACF's resolution for these.
+	 *
+	 * The schedule repeater is still updated via update_field() because ACF handles
+	 * repeater index prefixing correctly at the repeater level.
+	 *
+	 * @param int   $post_id Post ID.
+	 * @param array $data    Associative row data from CSV.
+	 * @return void
+	 */
+	private function save_station_fields( $post_id, $data ) {
+		$call_letters = trim( $data['call_letters'] );
+		$frequency    = trim( $data['frequency_info_frequency'] );
+		$modulator    = trim( $data['frequency_info_modulator'] );
+		$city_name    = trim( $data['location_city'] );
+		$state_name   = trim( $data['location_state_province'] );
+		$country_name = trim( $data['location_country'] );
+
+		// Simple scalar fields — write meta key + ACF field reference directly.
+		$scalar_values = array(
+			'frequency_info_call_letters' => $call_letters,
+			'frequency_info_frequency'    => $frequency,
+			'frequency_info_modulator'    => $modulator,
+		);
+
+		foreach ( $scalar_values as $meta_key => $value ) {
+			if ( $value ) {
+				update_post_meta( $post_id, $meta_key, $value );
+				update_post_meta( $post_id, '_' . $meta_key, self::META_FIELDS[ $meta_key ] );
+			}
+		}
+
+		// Taxonomy fields — resolve term IDs then write directly.
+		if ( $city_name ) {
+			$city_id = $this->get_or_create_term( $city_name, 'city' );
+			if ( $city_id ) {
+				update_post_meta( $post_id, 'location_city', $city_id );
+				update_post_meta( $post_id, '_location_city', self::META_FIELDS['location_city'] );
+			}
+		}
+
+		if ( $state_name ) {
+			$state_id = $this->get_or_create_term( $state_name, 'province_or_state' );
+			if ( $state_id ) {
+				update_post_meta( $post_id, 'location_state_province', $state_id );
+				update_post_meta( $post_id, '_location_state_province', self::META_FIELDS['location_state_province'] );
+			}
+		}
+
+		if ( $country_name ) {
+			$country_id = $this->get_or_create_term( $country_name, 'country' );
+			if ( $country_id ) {
+				update_post_meta( $post_id, 'location_country', $country_id );
+				update_post_meta( $post_id, '_location_country', self::META_FIELDS['location_country'] );
+			}
+		}
+
+		// Schedule repeater — update_field() handles index prefixing correctly here.
+		$schedule = array();
+		foreach ( array( 'schedule_0_start_time_utc', 'schedule_1_start_time_utc' ) as $col ) {
+			$time_str = trim( $data[ $col ] ?? '' );
+			if ( $time_str ) {
+				$converted = $this->convert_time( $time_str );
+				if ( $converted ) {
+					$schedule[] = array( 'start_time_utc' => $converted );
+				}
+			}
+		}
+
+		if ( ! empty( $schedule ) ) {
+			update_field( self::FIELD_SCHEDULE, $schedule, $post_id );
+		}
+	}
+
+	/**
+	 * Get an existing taxonomy term by name or create it.
+	 *
+	 * @param string $name     Term name.
+	 * @param string $taxonomy Taxonomy slug.
+	 * @return int|null Term ID or null on failure.
+	 */
+	private function get_or_create_term( $name, $taxonomy ) {
+		$term = get_term_by( 'name', $name, $taxonomy );
+		if ( $term ) {
+			return $term->term_id;
+		}
+
+		$result = wp_insert_term( $name, $taxonomy );
+		if ( is_wp_error( $result ) ) {
+			return null;
+		}
+
+		return $result['term_id'];
+	}
+
+	/**
+	 * Convert a 12-hour time string to H:i:s format.
+	 *
+	 * @param string $time_str e.g. "4:00:00 AM".
+	 * @return string|null e.g. "04:00:00", or null on failure.
+	 */
+	private function convert_time( $time_str ) {
+		$timestamp = strtotime( $time_str );
+		if ( false === $timestamp ) {
+			return null;
+		}
+		return gmdate( 'H:i:s', $timestamp );
+	}
+}

--- a/wp-content/plugins/tw-stations/includes/class-tw-station-import-processor.php
+++ b/wp-content/plugins/tw-stations/includes/class-tw-station-import-processor.php
@@ -26,12 +26,13 @@ class TW_Station_Import_Processor {
 	 * (update_field on a sub-field key saves without the parent group prefix.)
 	 */
 	const META_FIELDS = array(
-		'frequency_info_call_letters' => 'field_69810ae7bd0f4',
-		'frequency_info_frequency'    => 'field_687ea33a3f5b0',
-		'frequency_info_modulator'    => 'field_687ea40f3f5b1',
-		'location_city'               => 'field_689a4ce0b6e60',
-		'location_state_province'     => 'field_689a4d22b6e62',
-		'location_country'            => 'field_689a4d0ab6e61',
+		'station_info_call_letters' => 'field_69810ae7bd0f4',
+		'station_info_frequency'    => 'field_687ea33a3f5b0',
+		'station_info_modulator'    => 'field_687ea40f3f5b1',
+		'station_info_website'      => 'field_69810fc4b700e',
+		'location_city'             => 'field_689a4ce0b6e60',
+		'location_state_province'   => 'field_689a4d22b6e62',
+		'location_country'          => 'field_689a4d0ab6e61',
 	);
 
 	/**
@@ -71,6 +72,9 @@ class TW_Station_Import_Processor {
 		}
 
 		$header = fgetcsv( $handle );
+		if ( $header ) {
+			$header = array_map( 'trim', $header );
+		}
 		if ( ! $header ) {
 			$this->results['errors'][] = array(
 				'title'   => '',
@@ -81,19 +85,21 @@ class TW_Station_Import_Processor {
 		}
 
 		$row_num = 1;
-		while ( ( $row = fgetcsv( $handle ) ) !== false ) {
-			$row_num++;
+		$row     = fgetcsv( $handle );
+		while ( false !== $row ) {
+			++$row_num;
 
 			if ( count( $row ) !== count( $header ) ) {
 				$this->results['errors'][] = array(
 					'title'   => '',
 					'message' => "Row $row_num has wrong column count.",
 				);
-				continue;
+			} else {
+				$data = array_combine( $header, $row );
+				$this->process_row( $data, $update );
 			}
 
-			$data = array_combine( $header, $row );
-			$this->process_row( $data, $update );
+			$row = fgetcsv( $handle );
 		}
 
 		fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
@@ -207,13 +213,13 @@ class TW_Station_Import_Processor {
 	/**
 	 * Save all ACF fields for a station post.
 	 *
-	 * Frequency info and location fields are written via update_post_meta() with
-	 * explicit meta key names (e.g. frequency_info_frequency, location_city) plus
-	 * their ACF field-key reference rows (_frequency_info_frequency, etc.).
+	 * Station info and location fields are written via update_post_meta() with
+	 * explicit meta key names (e.g. station_info_frequency, location_city) plus
+	 * their ACF field-key reference rows (_station_info_frequency, etc.).
 	 *
-	 * Using update_field() on a group sub-field key saves the value under just the
-	 * sub-field name (e.g. "frequency") instead of the prefixed name
-	 * ("frequency_info_frequency"), so we bypass ACF's resolution for these.
+	 * ACF constructs sub-field meta keys as {group_name}_{sub_field_name}, so we
+	 * write directly with update_post_meta() using those prefixed keys to ensure
+	 * ACF can read them back correctly.
 	 *
 	 * The schedule repeater is still updated via update_field() because ACF handles
 	 * repeater index prefixing correctly at the repeater level.
@@ -226,15 +232,17 @@ class TW_Station_Import_Processor {
 		$call_letters = trim( $data['call_letters'] );
 		$frequency    = trim( $data['frequency_info_frequency'] );
 		$modulator    = trim( $data['frequency_info_modulator'] );
+		$website      = trim( $data['website'] ?? '' );
 		$city_name    = trim( $data['location_city'] );
 		$state_name   = trim( $data['location_state_province'] );
 		$country_name = trim( $data['location_country'] );
 
 		// Simple scalar fields — write meta key + ACF field reference directly.
 		$scalar_values = array(
-			'frequency_info_call_letters' => $call_letters,
-			'frequency_info_frequency'    => $frequency,
-			'frequency_info_modulator'    => $modulator,
+			'station_info_call_letters' => $call_letters,
+			'station_info_frequency'    => $frequency,
+			'station_info_modulator'    => $modulator,
+			'station_info_website'      => $website,
 		);
 
 		foreach ( $scalar_values as $meta_key => $value ) {

--- a/wp-content/plugins/tw-stations/includes/class-tw-station-import-processor.php
+++ b/wp-content/plugins/tw-stations/includes/class-tw-station-import-processor.php
@@ -271,17 +271,6 @@ class TW_Station_Import_Processor {
 			}
 		}
 
-		// Wipe any existing schedule rows before writing fresh ones.
-		// The first import may have written bare meta keys (schedule_0_start_time_utc, etc.)
-		// that update_field() doesn't clean up, causing duplicates on re-import.
-		$existing_count = (int) get_post_meta( $post_id, 'schedule', true );
-		for ( $i = 0; $i < $existing_count; $i++ ) {
-			delete_post_meta( $post_id, "schedule_{$i}_start_time_utc" );
-			delete_post_meta( $post_id, "_schedule_{$i}_start_time_utc" );
-		}
-		delete_post_meta( $post_id, 'schedule' );
-		delete_post_meta( $post_id, '_schedule' );
-
 		// Schedule repeater — update_field() handles index prefixing correctly here.
 		$schedule = array();
 		foreach ( array( 'schedule_0_start_time_utc', 'schedule_1_start_time_utc' ) as $col ) {

--- a/wp-content/plugins/tw-stations/includes/class-tw-station-import-processor.php
+++ b/wp-content/plugins/tw-stations/includes/class-tw-station-import-processor.php
@@ -30,9 +30,6 @@ class TW_Station_Import_Processor {
 		'station_info_frequency'    => 'field_687ea33a3f5b0',
 		'station_info_modulator'    => 'field_687ea40f3f5b1',
 		'station_info_website'      => 'field_69810fc4b700e',
-		'location_city'             => 'field_689a4ce0b6e60',
-		'location_state_province'   => 'field_689a4d22b6e62',
-		'location_country'          => 'field_689a4d0ab6e61',
 	);
 
 	/**
@@ -252,28 +249,25 @@ class TW_Station_Import_Processor {
 			}
 		}
 
-		// Taxonomy fields — resolve term IDs then write directly.
+		// Taxonomy terms — assign via wp_set_object_terms() using the registered taxonomies.
 		if ( $city_name ) {
 			$city_id = $this->get_or_create_term( $city_name, 'city' );
 			if ( $city_id ) {
-				update_post_meta( $post_id, 'location_city', $city_id );
-				update_post_meta( $post_id, '_location_city', self::META_FIELDS['location_city'] );
+				wp_set_object_terms( $post_id, $city_id, 'city' );
 			}
 		}
 
 		if ( $state_name ) {
 			$state_id = $this->get_or_create_term( $state_name, 'province_or_state' );
 			if ( $state_id ) {
-				update_post_meta( $post_id, 'location_state_province', $state_id );
-				update_post_meta( $post_id, '_location_state_province', self::META_FIELDS['location_state_province'] );
+				wp_set_object_terms( $post_id, $state_id, 'province_or_state' );
 			}
 		}
 
 		if ( $country_name ) {
 			$country_id = $this->get_or_create_term( $country_name, 'country' );
 			if ( $country_id ) {
-				update_post_meta( $post_id, 'location_country', $country_id );
-				update_post_meta( $post_id, '_location_country', self::META_FIELDS['location_country'] );
+				wp_set_object_terms( $post_id, $country_id, 'country' );
 			}
 		}
 

--- a/wp-content/plugins/tw-stations/includes/class-tw-station-import-processor.php
+++ b/wp-content/plugins/tw-stations/includes/class-tw-station-import-processor.php
@@ -277,6 +277,17 @@ class TW_Station_Import_Processor {
 			}
 		}
 
+		// Wipe any existing schedule rows before writing fresh ones.
+		// The first import may have written bare meta keys (schedule_0_start_time_utc, etc.)
+		// that update_field() doesn't clean up, causing duplicates on re-import.
+		$existing_count = (int) get_post_meta( $post_id, 'schedule', true );
+		for ( $i = 0; $i < $existing_count; $i++ ) {
+			delete_post_meta( $post_id, "schedule_{$i}_start_time_utc" );
+			delete_post_meta( $post_id, "_schedule_{$i}_start_time_utc" );
+		}
+		delete_post_meta( $post_id, 'schedule' );
+		delete_post_meta( $post_id, '_schedule' );
+
 		// Schedule repeater — update_field() handles index prefixing correctly here.
 		$schedule = array();
 		foreach ( array( 'schedule_0_start_time_utc', 'schedule_1_start_time_utc' ) as $col ) {

--- a/wp-content/plugins/tw-stations/tw-stations.php
+++ b/wp-content/plugins/tw-stations/tw-stations.php
@@ -47,7 +47,7 @@ function tw_stations_post_type() {
 		'description'         => __( 'Manages the list of Stations that air The World', 'text_domain' ),
 		'labels'              => $labels,
 		'supports'            => array( 'title', 'editor', 'excerpt', 'thumbnail' ),
-		'taxonomies'          => array(),
+		'taxonomies'          => array( 'city', 'province_or_state', 'country' ),
 		'rewrite'             => array(
 			'slug'       => 'stations',
 			'with_front' => false,

--- a/wp-content/plugins/tw-stations/tw-stations.php
+++ b/wp-content/plugins/tw-stations/tw-stations.php
@@ -77,3 +77,15 @@ function tw_stations_post_type() {
 	register_post_type( 'station', $args );
 }
 add_action( 'init', 'tw_stations_post_type', 0 );
+
+// Shared import processor (used by both admin UI and WP-CLI).
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-tw-station-import-processor.php';
+
+// Admin import page.
+require_once plugin_dir_path( __FILE__ ) . 'admin/class-tw-station-admin.php';
+TW_Station_Admin::init();
+
+// Register WP-CLI import command.
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once plugin_dir_path( __FILE__ ) . 'cli/class-tw-station-importer.php';
+}

--- a/wp-content/themes/the-world/acf-json/group_687ea335c5c2c.json
+++ b/wp-content/themes/the-world/acf-json/group_687ea335c5c2c.json
@@ -116,106 +116,6 @@
             ]
         },
         {
-            "key": "field_689ba40b3377d",
-            "label": "Location",
-            "name": "location",
-            "aria-label": "",
-            "type": "group",
-            "instructions": "",
-            "required": 0,
-            "conditional_logic": 0,
-            "wrapper": {
-                "width": "",
-                "class": "",
-                "id": ""
-            },
-            "show_in_graphql": 1,
-            "layout": "block",
-            "sub_fields": [
-                {
-                    "key": "field_689a4ce0b6e60",
-                    "label": "City",
-                    "name": "city",
-                    "aria-label": "",
-                    "type": "taxonomy",
-                    "instructions": "",
-                    "required": 0,
-                    "conditional_logic": 0,
-                    "wrapper": {
-                        "width": "",
-                        "class": "",
-                        "id": ""
-                    },
-                    "show_in_graphql": 1,
-                    "taxonomy": "city",
-                    "add_term": 1,
-                    "save_terms": 0,
-                    "load_terms": 0,
-                    "return_format": "id",
-                    "field_type": "select",
-                    "allow_null": 0,
-                    "allow_in_bindings": 0,
-                    "bidirectional": 0,
-                    "multiple": 0,
-                    "bidirectional_target": []
-                },
-                {
-                    "key": "field_689a4d22b6e62",
-                    "label": "State \/ Province",
-                    "name": "state_province",
-                    "aria-label": "",
-                    "type": "taxonomy",
-                    "instructions": "",
-                    "required": 0,
-                    "conditional_logic": 0,
-                    "wrapper": {
-                        "width": "",
-                        "class": "",
-                        "id": ""
-                    },
-                    "show_in_graphql": 1,
-                    "taxonomy": "province_or_state",
-                    "add_term": 1,
-                    "save_terms": 0,
-                    "load_terms": 0,
-                    "return_format": "id",
-                    "field_type": "select",
-                    "allow_null": 0,
-                    "allow_in_bindings": 0,
-                    "bidirectional": 0,
-                    "multiple": 0,
-                    "bidirectional_target": []
-                },
-                {
-                    "key": "field_689a4d0ab6e61",
-                    "label": "Country",
-                    "name": "country",
-                    "aria-label": "",
-                    "type": "taxonomy",
-                    "instructions": "",
-                    "required": 0,
-                    "conditional_logic": 0,
-                    "wrapper": {
-                        "width": "",
-                        "class": "",
-                        "id": ""
-                    },
-                    "show_in_graphql": 1,
-                    "taxonomy": "country",
-                    "add_term": 0,
-                    "save_terms": 0,
-                    "load_terms": 0,
-                    "return_format": "id",
-                    "field_type": "select",
-                    "allow_null": 0,
-                    "allow_in_bindings": 0,
-                    "bidirectional": 0,
-                    "multiple": 0,
-                    "bidirectional_target": []
-                }
-            ]
-        },
-        {
             "key": "field_689ba27787ae5",
             "label": "Schedule",
             "name": "schedule",
@@ -284,5 +184,5 @@
     "graphql_field_name": "station_info",
     "map_graphql_types_from_location_rules": 0,
     "graphql_types": "",
-    "modified": 1775680332
+    "modified": 1776183856
 }

--- a/wp-content/themes/the-world/acf-json/group_687ea335c5c2c.json
+++ b/wp-content/themes/the-world/acf-json/group_687ea335c5c2c.json
@@ -1,11 +1,11 @@
 {
     "key": "group_687ea335c5c2c",
-    "title": "Station info",
+    "title": "Station Fields",
     "fields": [
         {
             "key": "field_689ba465bba2b",
-            "label": "Frequency Info",
-            "name": "frequency_info",
+            "label": "Station Info",
+            "name": "station_info",
             "aria-label": "",
             "type": "group",
             "instructions": "",
@@ -19,6 +19,28 @@
             "show_in_graphql": 1,
             "layout": "block",
             "sub_fields": [
+                {
+                    "key": "field_69810ae7bd0f4",
+                    "label": "Call Letters",
+                    "name": "call_letters",
+                    "aria-label": "",
+                    "type": "text",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "show_in_graphql": 1,
+                    "default_value": "",
+                    "maxlength": "",
+                    "allow_in_bindings": 0,
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": ""
+                },
                 {
                     "key": "field_687ea33a3f5b0",
                     "label": "Frequency",
@@ -71,6 +93,25 @@
                     "placeholder": "",
                     "create_options": 0,
                     "save_options": 0
+                },
+                {
+                    "key": "field_69810fc4b700e",
+                    "label": "Website",
+                    "name": "website",
+                    "aria-label": "",
+                    "type": "url",
+                    "instructions": "",
+                    "required": 0,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "",
+                        "class": "",
+                        "id": ""
+                    },
+                    "show_in_graphql": 1,
+                    "default_value": "",
+                    "allow_in_bindings": 0,
+                    "placeholder": ""
                 }
             ]
         },
@@ -238,9 +279,10 @@
     "active": true,
     "description": "",
     "show_in_rest": 1,
+    "display_title": "",
     "show_in_graphql": 1,
     "graphql_field_name": "station_info",
     "map_graphql_types_from_location_rules": 0,
     "graphql_types": "",
-    "modified": 1755030771
+    "modified": 1775680332
 }


### PR DESCRIPTION
- Creates a Stations Importer so I don't have to add them by hand
- Updates ACF Station field group to live 

## To Review

- [ ] Checkout Branch.
- [ ] If you have a dev server already running, shut it down: `docker compose down`.
- [ ] Delete the current image: `docker rmi the-world-cms-wordpress-wordpress:latest`.
- [ ] Start up dev server: `docker compose up`.
- [ ] Go to http://localhost:8090/wp-login.php.

> ...then...

- [ ] Go To Stations > [Import Stations](http://localhost:8090/wp-admin/edit.php?post_type=station&page=tw-station-import) 
- [ ] Upload ~[this csv](https://github.com/user-attachments/files/26580763/the-world-stations-list.csv)~ with all the station's info. ~**4/13 EDIT, upload [this CSV](https://github.com/user-attachments/files/26689541/stations-list-apr-13.csv) instead!**~ **4/14 EDIT [USE THIS CSV](https://github.com/user-attachments/files/26718754/stations-list-apr-14.csv)**
- [ ] Check the box to update existing records
- [ ] Run it
- [ ] When complete, cherry pick a few stations and confirm that the fields have been added properly, including adding a website.


