### PR TITLE
fix(twendpointhelper): fid slug check existence of attachment object

### DIFF
--- a/wp-content/plugins/tw-endpoint-helper/tw-endpoint-helper.php
+++ b/wp-content/plugins/tw-endpoint-helper/tw-endpoint-helper.php
@@ -602,7 +602,9 @@ function _peh_get_object_with_fid( $slug ) {
 		$object_attachment  = array_pop( $object_attachments );
 		$object_segment     = array_pop( $object_segments );
 
-		if ( 0 === strpos( $object_attachment->post_mime_type, 'audio/' ) && $object_segment ) {
+		if ( $object_attachment && 0 === strpos( $object_attachment->post_mime_type, 'audio/' ) && $object_segment ) {
+			// Both an audio attachment and segment wher found for the fid.
+			// We want to return the route for the segment.
 			$object = $object_segment;
 		} else {
 			$object = $object_attachment;


### PR DESCRIPTION
- fix error in REST alias endpoint when trying to look up numeric slug as Drupal file id (fid)

## To Review

- [ ] Code Review (New Relic logs did not include the slug parameter to be able to know which fid triggered this logic error.)
